### PR TITLE
Adjust text showing for short branch name ie. master.

### DIFF
--- a/Scripts/iconVersioning.sh
+++ b/Scripts/iconVersioning.sh
@@ -26,7 +26,7 @@ build_num=`git log --oneline | wc -l`
 shopt -s extglob
 build_num="${build_num##*( )}"
 shopt -u extglob
-caption="${version} ($build_num) ${branch} ${commit}"
+caption="${version} ($build_num)\n${branch}\n${commit}"
 echo $caption
 
 function processIcon() {


### PR DESCRIPTION
Previous new adjustment didn't test on short branch name ie. master, thus text gets together at the bottom, and not easy to read. This will fix it and make it text-length independent by using newline.
