### PR TITLE
fix version and build number overlay when using placeholders

### DIFF
--- a/Scripts/iconVersioning.sh
+++ b/Scripts/iconVersioning.sh
@@ -28,8 +28,8 @@ if [[ "$convertValidation" = true || "$gsValidation" = true ]]; then
 exit 0;
 fi
 
-version=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE}"`
-build_num=`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${INFOPLIST_FILE}"`
+version=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${CONFIGURATION_BUILD_DIR}/${INFOPLIST_PATH}"`
+build_num=`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${CONFIGURATION_BUILD_DIR}/${INFOPLIST_PATH}"`
 
 # Check if we are under a Git or Hg repo
 if [ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1; then


### PR DESCRIPTION
Hi,
I’ve run into an issue with the script. The way I'm setting version and build number is by using xcconfig files that configure `CURRENT_PROJECT_VERSION` and `BUILD_NUMBER`. Info.plist from the project has placeholders and they ended up on the icon overlay, e.g. `${BUILD_NUMBER}`.
Using Info.plist from `${CONFIGURATION_BUILD_DIR}` fixes this.